### PR TITLE
Fix username error in windows tests

### DIFF
--- a/appdirs_test.go
+++ b/appdirs_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os/user"
 	"runtime"
+	"strings"
 	"testing"
 )
 
@@ -12,35 +13,49 @@ func getExpectations() map[string]string {
 	if err != nil {
 		panic(err)
 	}
-
+	var userName string
+	if runtime.GOOS == "windows" {
+		userName = extractDomain(u.Username)
+	} else {
+		userName = u.Username
+	}
 	expectations := map[string]map[string]string{
 		"darwin": {
-			"UserData":   fmt.Sprintf("/Users/%s/Library/Application Support/Testing/1.0.0", u.Username),
-			"UserCache":  fmt.Sprintf("/Users/%s/Library/Caches/Testing/1.0.0", u.Username),
-			"UserConfig": fmt.Sprintf("/Users/%s/Library/Application Support/Testing/1.0.0", u.Username),
-			"UserLog":    fmt.Sprintf("/Users/%s/Library/Logs/Testing/1.0.0", u.Username),
+			"UserData":   fmt.Sprintf("/Users/%s/Library/Application Support/Testing/1.0.0", userName),
+			"UserCache":  fmt.Sprintf("/Users/%s/Library/Caches/Testing/1.0.0", userName),
+			"UserConfig": fmt.Sprintf("/Users/%s/Library/Application Support/Testing/1.0.0", userName),
+			"UserLog":    fmt.Sprintf("/Users/%s/Library/Logs/Testing/1.0.0", userName),
 			"SiteData":   "/Library/Application Support/Testing/1.0.0",
 			"SiteConfig": "/Library/Application Support/Testing/1.0.0",
 		},
 		"linux": {
-			"UserData":   fmt.Sprintf("/home/%s/.local/share/Testing/1.0.0", u.Username),
-			"UserCache":  fmt.Sprintf("/home/%s/.cache/Testing/1.0.0", u.Username),
-			"UserConfig": fmt.Sprintf("/home/%s/.config/Testing/1.0.0", u.Username),
-			"UserLog":    fmt.Sprintf("/home/%s/.cache/Testing/1.0.0/log", u.Username),
+			"UserData":   fmt.Sprintf("/home/%s/.local/share/Testing/1.0.0", userName),
+			"UserCache":  fmt.Sprintf("/home/%s/.cache/Testing/1.0.0", userName),
+			"UserConfig": fmt.Sprintf("/home/%s/.config/Testing/1.0.0", userName),
+			"UserLog":    fmt.Sprintf("/home/%s/.cache/Testing/1.0.0/log", userName),
 			"SiteData":   "/usr/local/share/Testing/1.0.0",
 			"SiteConfig": "/etc/xdg/Testing/1.0.0",
 		},
 		"windows": {
-			"UserData":   fmt.Sprintf("C:\\Users\\%s\\AppData\\Local\\Tester\\Testing\\1.0.0", u.Username),
-			"UserCache":  fmt.Sprintf("C:\\Users\\%s\\AppData\\Local\\Tester\\Testing\\Cache\\1.0.0", u.Username),
-			"UserConfig": fmt.Sprintf("C:\\Users\\%s\\AppData\\Local\\Tester\\Testing\\1.0.0", u.Username),
-			"UserLog":    fmt.Sprintf("C:\\Users\\%s\\AppData\\Local\\Tester\\Testing\\1.0.0\\Logs", u.Username),
+			"UserData":   fmt.Sprintf("C:\\Users\\%s\\AppData\\Local\\Tester\\Testing\\1.0.0", userName),
+			"UserCache":  fmt.Sprintf("C:\\Users\\%s\\AppData\\Local\\Tester\\Testing\\Cache\\1.0.0", userName),
+			"UserConfig": fmt.Sprintf("C:\\Users\\%s\\AppData\\Local\\Tester\\Testing\\1.0.0", userName),
+			"UserLog":    fmt.Sprintf("C:\\Users\\%s\\AppData\\Local\\Tester\\Testing\\1.0.0\\Logs", userName),
 			"SiteData":   "C:\\ProgramData\\Tester\\Testing\\1.0.0",
 			"SiteConfig": "C:\\ProgramData\\Tester\\Testing\\1.0.0",
 		},
 	}
-
 	return expectations[runtime.GOOS]
+}
+
+// extractDomain extract an optional domain from a Windows username
+// e.g. "domain\\user" => "user"
+func extractDomain(s string) string {
+	p := strings.Split(s, "\\")
+	if len(p) > 1 {
+		return p[1]
+	}
+	return p[0]
 }
 
 func testApp() *App {


### PR DESCRIPTION
The current windows tests fail both on gitlab and on a local windows desktop.

The reason is that the tests use a different method for obtaining the current username. The username in the tests also include the user's domain (e.g. `fv-az1435-285\runneradmin` instead of `runneradmin`), while username in the library code doesn't.

I added a patch to the tests which removes the domain from the username in the windows tests.

With this patch the windows tests pass again, both locally and on gitlab.